### PR TITLE
List of environment variables to be specified in fresque.ini

### DIFF
--- a/fresque.ini
+++ b/fresque.ini
@@ -172,4 +172,16 @@ log = /path/to/resque-scheduler.log
 ; handler = RotatingFile
 ; target =  /path/to/resque-scheduler.log
 
+[Env]
+
+; Environment variables that you want to pass to the workers
+; Useful for example if you don't keep the database credentials or API keys in your source code
+
+; Passing a key only will search for its value from the getenv() function
+; MYSQL_USER =
+; MYSQL_PASSWORD =
+
+; Passing a key and a value will set the env variable to this value
+; APP_ENV = dev
+
 ; That's all folks !

--- a/lib/Fresque.php
+++ b/lib/Fresque.php
@@ -471,8 +471,13 @@ class Fresque
 
             $libraryPath = rtrim($libraryPath, '/');
 
+            // build environment variables string to be passed to the worker
             $env_vars = "";
-            foreach($_ENV as $env_name => $env_value) {
+            foreach($this->runtime['Env'] as $env_name => $env_value) {
+                // if only the name is supplied, we get the value from environment
+                if (strlen($env_value) == 0) {
+                    $env_value = getenv($env_name);
+                }
                 $env_vars .= $env_name . '=' . escapeshellarg($env_value) . " \\\n";
             }
 
@@ -1172,7 +1177,8 @@ class Fresque
                 'interval',
                 'handler',
                 'target'
-            )
+            ),
+            'Env' => array()
         );
 
         foreach ($settings as $scope => $param_names) {


### PR DESCRIPTION
List of environment variables are now specified in fresque.ini. If an empty value is provided, the value will be fetched from the environment with the getenv() function